### PR TITLE
[configure fix] fixed NDNCPPLIB to NDNCPPDIR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,12 +12,12 @@ libs_libchrono_chat2013_la_SOURCES = src/chrono-chat.cpp \
 libs_libconference_discovery_la_SOURCES = src/sync-based-discovery.cpp \
   src/conference-discovery-sync.cpp
 
-libs_libchrono_chat2013_la_CPPFLAGS = -I$(top_srcdir)/include -I@PROTOBUFDIR@ -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+libs_libchrono_chat2013_la_CPPFLAGS = -I$(top_srcdir)/include -I@PROTOBUFDIR@ -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 libs_libchrono_chat2013_la_LDFLAGS = -L@PROTOBUFDIR@ -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lcrypto -lprotobuf
 
-libs_libconference_discovery_la_CPPFLAGS = -I$(top_srcdir)/include -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+libs_libconference_discovery_la_CPPFLAGS = -I$(top_srcdir)/include -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 libs_libconference_discovery_la_LDFLAGS = -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lcrypto
   
-bin_test_both_CPPFLAGS = -I$(top_srcdir)/include -I@BOOSTDIR@ -I@PROTOBUFDIR@ -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+bin_test_both_CPPFLAGS = -I$(top_srcdir)/include -I@BOOSTDIR@ -I@PROTOBUFDIR@ -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 bin_test_both_LDFLAGS = -L@PROTOBUFDIR@ -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lprotobuf -lcrypto
 bin_test_both_LDADD = libs/libchrono-chat2013.la libs/libconference-discovery.la

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,9 +93,7 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/missing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
@@ -360,11 +358,11 @@ libs_libchrono_chat2013_la_SOURCES = src/chrono-chat.cpp \
 libs_libconference_discovery_la_SOURCES = src/sync-based-discovery.cpp \
   src/conference-discovery-sync.cpp
 
-libs_libchrono_chat2013_la_CPPFLAGS = -I$(top_srcdir)/include -I@PROTOBUFDIR@ -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+libs_libchrono_chat2013_la_CPPFLAGS = -I$(top_srcdir)/include -I@PROTOBUFDIR@ -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 libs_libchrono_chat2013_la_LDFLAGS = -L@PROTOBUFDIR@ -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lcrypto -lprotobuf
-libs_libconference_discovery_la_CPPFLAGS = -I$(top_srcdir)/include -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+libs_libconference_discovery_la_CPPFLAGS = -I$(top_srcdir)/include -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 libs_libconference_discovery_la_LDFLAGS = -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lcrypto
-bin_test_both_CPPFLAGS = -I$(top_srcdir)/include -I@BOOSTDIR@ -I@PROTOBUFDIR@ -I@NDNCPPLIB@ -I@CRYPTOLIB@ 
+bin_test_both_CPPFLAGS = -I$(top_srcdir)/include -I@BOOSTDIR@ -I@PROTOBUFDIR@ -I@NDNCPPDIR@ -I@CRYPTOLIB@ 
 bin_test_both_LDFLAGS = -L@PROTOBUFDIR@ -L@NDNCPPLIB@ -L@CRYPTOLIB@ -lndn-cpp -lprotobuf -lcrypto
 bin_test_both_LDADD = libs/libchrono-chat2013.la libs/libconference-discovery.la
 all: all-am

--- a/configure
+++ b/configure
@@ -8204,7 +8204,7 @@ $as_echo "$lt_cv_ld_force_load" >&6; }
       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
-	10.[012][,.]*)
+	10.[012]*)
 	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
 	10.*)
 	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
@@ -8983,10 +8983,6 @@ _lt_linker_boilerplate=`cat conftest.err`
 $RM -r conftest*
 
 
-## CAVEAT EMPTOR:
-## There is no encapsulation within the following macros, do not change
-## the running order or otherwise move them around unless you know exactly
-## what you are doing...
 if test -n "$compiler"; then
 
 lt_prog_compiler_no_builtin_flag=


### PR DESCRIPTION
- in Makefile.am, CPPFLAGS variables for targets were mistakenly
  assigned value of NDNCPPLIB (which point to library) instead of
  NDNCPPDIR (which points to headers)
