### PR TITLE
[build fix] package name, public includes and namespaces

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 AUTOMAKE_OPTIONS = subdir-objects
 
+pkginclude_HEADERS = include/chrono-chat.h include/external-observer.h include/conference-discovery-sync.h include/conference-info-factory.h include/conference-info.h include/sync-based-discovery.h
+
 lib_LTLIBRARIES = libs/libchrono-chat2013.la libs/libconference-discovery.la
 noinst_PROGRAMS = bin/test-both bin/test-chat
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@
 @SET_MAKE@
 
 
+
 VPATH = @srcdir@
 am__is_gnu_make = test -n '$(MAKEFILE_LIST)' && test -n '$(MAKELEVEL)'
 am__make_running_with_option = \
@@ -83,10 +84,10 @@ noinst_PROGRAMS = bin/test-both$(EXEEXT) bin/test-chat$(EXEEXT)
 subdir = .
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/configure $(am__configure_deps) \
-	$(top_srcdir)/config/depcomp COPYING config/ar-lib \
-	config/compile config/config.guess config/config.sub \
-	config/depcomp config/install-sh config/missing \
-	config/ltmain.sh $(top_srcdir)/config/ar-lib \
+	$(top_srcdir)/config/depcomp $(pkginclude_HEADERS) COPYING \
+	config/ar-lib config/compile config/config.guess \
+	config/config.sub config/depcomp config/install-sh \
+	config/missing config/ltmain.sh $(top_srcdir)/config/ar-lib \
 	$(top_srcdir)/config/compile $(top_srcdir)/config/config.guess \
 	$(top_srcdir)/config/config.sub \
 	$(top_srcdir)/config/install-sh $(top_srcdir)/config/ltmain.sh \
@@ -130,7 +131,7 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-am__installdirs = "$(DESTDIR)$(libdir)"
+am__installdirs = "$(DESTDIR)$(libdir)" "$(DESTDIR)$(pkgincludedir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 libs_libchrono_chat2013_la_LIBADD =
 am__dirstamp = $(am__leading_dot)dirstamp
@@ -218,6 +219,7 @@ am__can_run_installinfo = \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
+HEADERS = $(pkginclude_HEADERS)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -387,8 +389,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 AUTOMAKE_OPTIONS = subdir-objects
-
-#noinst_LTLIBRARIES = libs/libchrono-chat2013.la libs/libconference-discovery.la
+pkginclude_HEADERS = include/chrono-chat.h include/external-observer.h include/conference-discovery-sync.h include/conference-info-factory.h include/conference-info.h include/sync-based-discovery.h
 lib_LTLIBRARIES = libs/libchrono-chat2013.la libs/libconference-discovery.la
 libs_libchrono_chat2013_la_SOURCES = src/chrono-chat.cpp \
   src/chatbuf.pb.cc
@@ -666,6 +667,27 @@ clean-libtool:
 
 distclean-libtool:
 	-rm -f libtool config.lt
+install-pkgincludeHEADERS: $(pkginclude_HEADERS)
+	@$(NORMAL_INSTALL)
+	@list='$(pkginclude_HEADERS)'; test -n "$(pkgincludedir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(pkgincludedir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(pkgincludedir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_HEADER) $$files '$(DESTDIR)$(pkgincludedir)'"; \
+	  $(INSTALL_HEADER) $$files "$(DESTDIR)$(pkgincludedir)" || exit $$?; \
+	done
+
+uninstall-pkgincludeHEADERS:
+	@$(NORMAL_UNINSTALL)
+	@list='$(pkginclude_HEADERS)'; test -n "$(pkgincludedir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(pkgincludedir)'; $(am__uninstall_files_from_dir)
 
 ID: $(am__tagged_files)
 	$(am__define_uniq_tagged_files); mkid -fID $$unique
@@ -891,9 +913,9 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-am
-all-am: Makefile $(LTLIBRARIES) $(PROGRAMS)
+all-am: Makefile $(LTLIBRARIES) $(PROGRAMS) $(HEADERS)
 installdirs:
-	for dir in "$(DESTDIR)$(libdir)"; do \
+	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(pkgincludedir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -956,7 +978,7 @@ info: info-am
 
 info-am:
 
-install-data-am:
+install-data-am: install-pkgincludeHEADERS
 
 install-dvi: install-dvi-am
 
@@ -1004,7 +1026,7 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-libLTLIBRARIES
+uninstall-am: uninstall-libLTLIBRARIES uninstall-pkgincludeHEADERS
 
 .MAKE: install-am install-strip
 
@@ -1019,11 +1041,13 @@ uninstall-am: uninstall-libLTLIBRARIES
 	install-data-am install-dvi install-dvi-am install-exec \
 	install-exec-am install-html install-html-am install-info \
 	install-info-am install-libLTLIBRARIES install-man install-pdf \
-	install-pdf-am install-ps install-ps-am install-strip \
-	installcheck installcheck-am installdirs maintainer-clean \
-	maintainer-clean-generic mostlyclean mostlyclean-compile \
-	mostlyclean-generic mostlyclean-libtool pdf pdf-am ps ps-am \
-	tags tags-am uninstall uninstall-am uninstall-libLTLIBRARIES
+	install-pdf-am install-pkgincludeHEADERS install-ps \
+	install-ps-am install-strip installcheck installcheck-am \
+	installdirs maintainer-clean maintainer-clean-generic \
+	mostlyclean mostlyclean-compile mostlyclean-generic \
+	mostlyclean-libtool pdf pdf-am ps ps-am tags tags-am uninstall \
+	uninstall-am uninstall-libLTLIBRARIES \
+	uninstall-pkgincludeHEADERS
 
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.

--- a/configure
+++ b/configure
@@ -589,7 +589,7 @@ MAKEFLAGS=
 
 # Identity of this package.
 PACKAGE_NAME='ndnrtc-addon'
-PACKAGE_TARNAME='https://github.com/zhehaowang/ndnrtc-addon'
+PACKAGE_TARNAME='ndn-conference-discovery'
 PACKAGE_VERSION='1.0'
 PACKAGE_STRING='ndnrtc-addon 1.0'
 PACKAGE_BUGREPORT='wangzhehao410305@gmail.com'
@@ -1391,7 +1391,7 @@ Fine tuning of the installation directories:
   --localedir=DIR         locale-dependent data [DATAROOTDIR/locale]
   --mandir=DIR            man documentation [DATAROOTDIR/man]
   --docdir=DIR            documentation root
-                          [DATAROOTDIR/doc/https://github.com/zhehaowang/ndnrtc-addon]
+                          [DATAROOTDIR/doc/ndn-conference-discovery]
   --htmldir=DIR           html documentation [DOCDIR]
   --dvidir=DIR            dvi documentation [DOCDIR]
   --pdfdir=DIR            pdf documentation [DOCDIR]
@@ -3187,7 +3187,7 @@ fi
 
 
 # Define the identity of the package.
- PACKAGE='https://github.com/zhehaowang/ndnrtc-addon'
+ PACKAGE='ndn-conference-discovery'
  VERSION='1.0'
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.61])
-AC_INIT(ndnrtc-addon, 1.0, wangzhehao410305@gmail.com, https://github.com/zhehaowang/ndnrtc-addon)
+AC_INIT([ndnrtc-addon], [1.0], [wangzhehao410305@gmail.com], [ndn-conference-discovery])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(src)

--- a/include/chrono-chat.h
+++ b/include/chrono-chat.h
@@ -44,7 +44,6 @@
 #include <ndn-cpp/security/policy/no-verify-policy-manager.hpp>
 #include <ndn-cpp/transport/tcp-transport.hpp>
 
-#include "chatbuf.pb.h"
 #include "external-observer.h"
 
 #if NDN_CPP_HAVE_TIME_H

--- a/include/conference-discovery-sync.h
+++ b/include/conference-discovery-sync.h
@@ -22,12 +22,12 @@
 #include "external-observer.h"
 #include "conference-info-factory.h"
 
-using namespace std;
-using namespace ndn;
-using namespace ndn::func_lib;
+// using namespace std;
+// using namespace ndn;
+// using namespace ndn::func_lib;
 #if NDN_CPP_HAVE_STD_FUNCTION && NDN_CPP_WITH_STD_FUNCTION
 // In the std library, the placeholders are in a different namespace than boost.
-using namespace func_lib::placeholders;
+// using namespace func_lib::placeholders;
 #endif
 
 // TODO: Constantly getting 'add conference' message during a test.
@@ -47,9 +47,9 @@ namespace conference_discovery
      * @param certificateName The certificate name for locating the certificate.
      */
 	ConferenceDiscovery
-	  (string broadcastPrefix, ptr_lib::shared_ptr<ConferenceDiscoveryObserver> observer, 
-	   ptr_lib::shared_ptr<ConferenceInfoFactory> factory, Face& face, KeyChain& keyChain, 
-	   Name certificateName)
+	  (std::string broadcastPrefix, ndn::ptr_lib::shared_ptr<ConferenceDiscoveryObserver> observer, 
+	   ndn::ptr_lib::shared_ptr<ConferenceInfoFactory> factory, ndn::Face& face, ndn::KeyChain& keyChain, 
+	   ndn::Name certificateName)
 	:  isHostingConference_(false), defaultDataFreshnessPeriod_(1000),
 	   defaultInterestLifetime_(1000), defaultHeartbeatInterval_(500), defaultTimeoutReexpressInterval_(300), 
 	   observer_(observer), factory_(factory), faceProcessor_(face), keyChain_(keyChain), 
@@ -70,7 +70,7 @@ namespace conference_discovery
 	 * @param conferenceInfo the info of this conference.
 	 */
 	void 
-	publishConference(std::string conferenceName, Name localPrefix, ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo);
+	publishConference(std::string conferenceName, ndn::Name localPrefix, ndn::ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo);
   
     /**
 	 * Stop publishing the conference of this instance. 
@@ -84,37 +84,37 @@ namespace conference_discovery
 	/**
 	 * getConferences returns the copy of list of conferences
 	 */
-	std::map<std::string, ptr_lib::shared_ptr<ConferenceInfo>>
+	std::map<std::string, ndn::ptr_lib::shared_ptr<ConferenceInfo>>
 	getConference() { return conferenceList_; };
     
     /**
      * getConference gets the conference info from list of conferences discovered (hosted by others)
      */
-    ptr_lib::shared_ptr<ConferenceInfo>
+    ndn::ptr_lib::shared_ptr<ConferenceInfo>
     getConference(std::string conferenceName) 
     {
-      std::map<string, ptr_lib::shared_ptr<ConferenceInfo>>::iterator item = conferenceList_.find
+      std::map<std::string, ndn::ptr_lib::shared_ptr<ConferenceInfo>>::iterator item = conferenceList_.find
         (conferenceName);
 	  if (item != conferenceList_.end()) {
 	    return item->second;
 	  }
 	  else {
 	    // TODO: nullptr vs NULL
-	    return NULL;
+	    return ndn::ptr_lib::shared_ptr<ConferenceInfo>(NULL);
 	  }
     };
     
     /**
      * getSelfConference gets the conference hosted by self;
      */
-    ptr_lib::shared_ptr<ConferenceInfo>
+    ndn::ptr_lib::shared_ptr<ConferenceInfo>
     getSelfConference() 
     {
       if (conferenceInfo_ != NULL) {
         return conferenceInfo_;
       }
       else {
-        return NULL;
+        return ndn::ptr_lib::shared_ptr<ConferenceInfo>(NULL);
       }
     };
     
@@ -138,8 +138,8 @@ namespace conference_discovery
 	 */
 	void
     onInterest
-	 (const ptr_lib::shared_ptr<const Name>& prefix,
-	  const ptr_lib::shared_ptr<const Interest>& interest, Transport& transport,
+	 (const ndn::ptr_lib::shared_ptr<const ndn::Name>& prefix,
+	  const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest, ndn::Transport& transport,
 	  uint64_t registerPrefixId);
     
 	/**
@@ -149,8 +149,8 @@ namespace conference_discovery
 	 */
 	void 
 	onData
-	  (const ptr_lib::shared_ptr<const Interest>& interest,
-	   const ptr_lib::shared_ptr<Data>& data);
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+	   const ndn::ptr_lib::shared_ptr<ndn::Data>& data);
   
 	/**
 	 * expressHeartbeatInterest expresses the interest for certain conference again,
@@ -159,8 +159,8 @@ namespace conference_discovery
 	 */
 	void
 	expressHeartbeatInterest
-	  (const ptr_lib::shared_ptr<const Interest>& interest,
-	   const ptr_lib::shared_ptr<const Interest>& conferenceInterest);
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+	   const ndn::ptr_lib::shared_ptr<const ndn::Interest>& conferenceInterest);
     
     /**
      * Remove registered prefix happens after a few seconds after stop hosting conference;
@@ -168,7 +168,7 @@ namespace conference_discovery
      */
     void
     removeRegisteredPrefix
-      (const ptr_lib::shared_ptr<const Interest>& interest);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest);
     
 	/**
 	 * This works as expressHeartbeatInterest's onData callback.
@@ -176,15 +176,15 @@ namespace conference_discovery
 	 */
 	void
 	onHeartbeatData
-	  (const ptr_lib::shared_ptr<const Interest>& interest,
-	   const ptr_lib::shared_ptr<Data>& data);
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+	   const ndn::ptr_lib::shared_ptr<ndn::Data>& data);
   
 	void 
 	dummyOnData
-	  (const ptr_lib::shared_ptr<const Interest>& interest,
-	   const ptr_lib::shared_ptr<Data>& data)
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+	   const ndn::ptr_lib::shared_ptr<ndn::Data>& data)
 	{
-	  cout << "Dummy onData called by ConferenceDiscovery." << endl;
+	  std::cout << "Dummy onData called by ConferenceDiscovery." << std::endl;
 	};
   
 	/**
@@ -194,13 +194,13 @@ namespace conference_discovery
 	 */
 	void
 	onTimeout
-	  (const ptr_lib::shared_ptr<const Interest>& interest);
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest);
   
 	void
 	onRegisterFailed
-	  (const ptr_lib::shared_ptr<const Name>& prefix)
+	  (const ndn::ptr_lib::shared_ptr<const ndn::Name>& prefix)
 	{
-	  cout << "Prefix " << prefix->toUri() << " registration failed." << endl;
+	  std::cout << "Prefix " << prefix->toUri() << " registration failed." << std::endl;
 	};
 	
 	std::string conferencesToString();
@@ -209,31 +209,31 @@ namespace conference_discovery
 	notifyObserver(MessageTypes type, const char *msg, double timestamp);
     
     
-    Face& faceProcessor_;
-	KeyChain& keyChain_;
+    ndn::Face& faceProcessor_;
+	ndn::KeyChain& keyChain_;
 	
-	Name certificateName_;
+	ndn::Name certificateName_;
     
 	bool isHostingConference_;
-	string conferenceBeingRemoved_;
+	std::string conferenceBeingRemoved_;
 	
-	Name conferenceName_;
+	ndn::Name conferenceName_;
 	uint64_t registeredPrefixId_;
   
-	const Milliseconds defaultDataFreshnessPeriod_;
-	const Milliseconds defaultInterestLifetime_;
-	const Milliseconds defaultHeartbeatInterval_;
-	const Milliseconds defaultTimeoutReexpressInterval_;
+	const ndn::Milliseconds defaultDataFreshnessPeriod_;
+	const ndn::Milliseconds defaultInterestLifetime_;
+	const ndn::Milliseconds defaultHeartbeatInterval_;
+	const ndn::Milliseconds defaultTimeoutReexpressInterval_;
   
 	//vector<std::string> conferenceList_;
 	
-	std::map<std::string, ptr_lib::shared_ptr<ConferenceInfo>> conferenceList_;
-	ptr_lib::shared_ptr<SyncBasedDiscovery> syncBasedDiscovery_;
-	ptr_lib::shared_ptr<ConferenceDiscoveryObserver> observer_;
+	std::map<std::string, ndn::ptr_lib::shared_ptr<ConferenceInfo>> conferenceList_;
+	ndn::ptr_lib::shared_ptr<SyncBasedDiscovery> syncBasedDiscovery_;
+	ndn::ptr_lib::shared_ptr<ConferenceDiscoveryObserver> observer_;
 	
-	ptr_lib::shared_ptr<ConferenceInfoFactory> factory_;
+	ndn::ptr_lib::shared_ptr<ConferenceInfoFactory> factory_;
 	// conferenceInfo_ is the info of the class currently being hosted
-	ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo_;
+	ndn::ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo_;
   };
 }
 

--- a/include/conference-info-factory.h
+++ b/include/conference-info-factory.h
@@ -12,36 +12,36 @@ namespace conference_discovery
   class ConferenceInfoFactory
   {
   public:
-    ConferenceInfoFactory(ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo)
+    ConferenceInfoFactory(ndn::ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo)
     {
       conferenceInfo_ = conferenceInfo;
     }
     
-    Blob 
-    serialize(ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo)
+    ndn::Blob 
+    serialize(ndn::ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo)
     {
       try {
         return conferenceInfo_->serialize(conferenceInfo);
       }
       catch (std::exception& e) {
-        cout << e.what() << endl;
+        std::cout << e.what() << std::endl;
       }
-      return Blob();
+      return ndn::Blob();
     }
     
-    ptr_lib::shared_ptr<ConferenceInfo> 
-    deserialize(Blob srcBlob)
+    ndn::ptr_lib::shared_ptr<ConferenceInfo> 
+    deserialize(ndn::Blob srcBlob)
     {
       try {
         return conferenceInfo_->deserialize(srcBlob);
       }
       catch (std::exception& e) {
-        cout << e.what() << endl;
+        std::cout << e.what() << std::endl;
       }
-      return NULL;
+      return ndn::ptr_lib::shared_ptr<ConferenceInfo>(NULL);
     }
   protected:
-    ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo_;
+    ndn::ptr_lib::shared_ptr<ConferenceInfo> conferenceInfo_;
   };
 }
 

--- a/include/conference-info.h
+++ b/include/conference-info.h
@@ -17,23 +17,19 @@ namespace conference_discovery
       timeoutCount = 0;
     }
     
-    virtual Blob serialize(const ptr_lib::shared_ptr<ConferenceInfo> &info) = 0;
-    virtual ptr_lib::shared_ptr<ConferenceInfo> deserialize(Blob srcBlob) = 0;
+    virtual ndn::Blob serialize(const ndn::ptr_lib::shared_ptr<ConferenceInfo> &info) = 0;
+    virtual ndn::ptr_lib::shared_ptr<ConferenceInfo> deserialize(ndn::Blob srcBlob) = 0;
     
     /**
      * This part with aliases as names needs to be better designed...
      */
-    Blob 
+    virtual ndn::Blob 
     serializeName()
-    {
-      
-    }
+    { return ndn::Blob(); }
     
-    ptr_lib::shared_ptr<ConferenceInfo> 
+    virtual ndn::ptr_lib::shared_ptr<ConferenceInfo> 
     deserializeName()
-    {
-      
-    }
+    { return ndn::ptr_lib::shared_ptr<ConferenceInfo>(NULL); }
     
     bool incrementTimeout()
     {
@@ -48,11 +44,11 @@ namespace conference_discovery
     void resetTimeout() { timeoutCount = 0; }
     int getTimeoutCount() { return timeoutCount; }
     
-    string getConferenceName() { return conferenceName_; }
-    void setConferenceName(string conferenceName) { conferenceName_ = conferenceName; }
+    std::string getConferenceName() { return conferenceName_; }
+    void setConferenceName(std::string conferenceName) { conferenceName_ = conferenceName; }
   protected:
     int timeoutCount;
-    string conferenceName_;
+    std::string conferenceName_;
   };
 }
 

--- a/include/sync-based-discovery.h
+++ b/include/sync-based-discovery.h
@@ -19,21 +19,21 @@
 
 #include "external-observer.h"
 
-using namespace std;
-using namespace ndn;
-using namespace ndn::func_lib;
+// using namespace std;
+// using namespace ndn;
+// using namespace ndn::func_lib;
 #if NDN_CPP_HAVE_STD_FUNCTION && NDN_CPP_WITH_STD_FUNCTION
 // In the std library, the placeholders are in a different namespace than boost.
-using namespace func_lib::placeholders;
+// using namespace ndn::func_lib::placeholders;
 #endif
 
 namespace conference_discovery
 {
-  typedef func_lib::function<void
+  typedef ndn::func_lib::function<void
 	(const std::vector<std::string>& syncData)>
 	  OnReceivedSyncData;
 
-  static MillisecondsSince1970 
+  static ndn::MillisecondsSince1970 
   ndn_getNowMilliseconds()
   {
     struct timeval t;
@@ -82,8 +82,8 @@ namespace conference_discovery
      * @param certificateName The certificate name for locating the certificate.
      */
     SyncBasedDiscovery
-      (Name broadcastPrefix, const OnReceivedSyncData& onReceivedSyncData, 
-       Face& face, KeyChain& keyChain, Name certificateName)
+      (ndn::Name broadcastPrefix, const OnReceivedSyncData& onReceivedSyncData, 
+       ndn::Face& face, ndn::KeyChain& keyChain, ndn::Name certificateName)
      : broadcastPrefix_(broadcastPrefix), onReceivedSyncData_(onReceivedSyncData), 
        face_(face), keyChain_(keyChain), certificateName_(certificateName), 
        contentCache_(&face), newComerDigest_("00"), currentDigest_(newComerDigest_),
@@ -95,7 +95,7 @@ namespace conference_discovery
         (broadcastPrefix, bind(&SyncBasedDiscovery::onRegisterFailed, this, _1), 
          bind(&SyncBasedDiscovery::onInterest, this, _1, _2, _3, _4));
       
-      Interest interest(broadcastPrefix);
+      ndn::Interest interest(broadcastPrefix);
       interest.getName().append(newComerDigest_);
       interest.setInterestLifetimeMilliseconds(defaultInterestLifetime_);
       // setAnswerOriginKind is deprecated
@@ -117,26 +117,26 @@ namespace conference_discovery
      * A lock for objects_ member?
      */
     void onData
-      (const ptr_lib::shared_ptr<const Interest>& interest,
-       const ptr_lib::shared_ptr<Data>& data);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+       const ndn::ptr_lib::shared_ptr<ndn::Data>& data);
       
     void onTimeout
-      (const ptr_lib::shared_ptr<const Interest>& interest);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest);
       
     void dummyOnData
-      (const ptr_lib::shared_ptr<const Interest>& interest,
-       const ptr_lib::shared_ptr<Data>& data);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+       const ndn::ptr_lib::shared_ptr<ndn::Data>& data);
        
     void expressBroadcastInterest
-      (const ptr_lib::shared_ptr<const Interest>& interest);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest);
     
     void onInterest
-      (const ptr_lib::shared_ptr<const Name>& prefix,
-       const ptr_lib::shared_ptr<const Interest>& interest, Transport& transport,
+      (const ndn::ptr_lib::shared_ptr<const ndn::Name>& prefix,
+       const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest, ndn::Transport& transport,
        uint64_t registerPrefixId);
     
     void onRegisterFailed
-      (const ptr_lib::shared_ptr<const Name>& prefix);
+      (const ndn::ptr_lib::shared_ptr<const ndn::Name>& prefix);
     
     /**
      * contentCacheAdd copied from ChronoSync2013 implementation
@@ -148,7 +148,7 @@ namespace conference_discovery
 	 * and remove from the pendingInterestTable_.
 	 * @param data
 	 */
-    void contentCacheAdd(const Data& data);
+    void contentCacheAdd(const ndn::Data& data);
     
     /**
      * Called when startPublishing, note that this function itself does 
@@ -169,9 +169,9 @@ namespace conference_discovery
     void recomputeDigest();
     
 	const std::string newComerDigest_;
-	const Milliseconds defaultDataFreshnessPeriod_;
-	const Milliseconds defaultInterestLifetime_;
-	const Milliseconds defaultInterval_;
+	const ndn::Milliseconds defaultDataFreshnessPeriod_;
+	const ndn::Milliseconds defaultInterestLifetime_;
+	const ndn::Milliseconds defaultInterval_;
     
     /**
      * These functions should be replaced, once we replace objects with something more
@@ -257,19 +257,19 @@ namespace conference_discovery
 	   * packet to the transport.
 	   */
 	  PendingInterest
-		(const ptr_lib::shared_ptr<const Interest>& interest,
-		 Transport& transport);
+		(const ndn::ptr_lib::shared_ptr<const ndn::Interest>& interest,
+		 ndn::Transport& transport);
 
 	  /**
 	   * Return the interest given to the constructor.
 	   */
-	  const ptr_lib::shared_ptr<const Interest>&
+	  const ndn::ptr_lib::shared_ptr<const ndn::Interest>&
 	  getInterest() { return interest_; }
 
 	  /**
 	   * Return the transport given to the constructor.
 	   */
-	  Transport&
+	  ndn::Transport&
 	  getTransport() { return transport_; }
 
 	  /**
@@ -278,29 +278,29 @@ namespace conference_discovery
 	   * @return true if this interest timed out, otherwise false.
 	   */
 	  bool
-	  isTimedOut(MillisecondsSince1970 nowMilliseconds)
+	  isTimedOut(ndn::MillisecondsSince1970 nowMilliseconds)
 	  {
 		return timeoutTimeMilliseconds_ >= 0.0 && nowMilliseconds >= timeoutTimeMilliseconds_;
 	  }
 
 	private:
-	  ptr_lib::shared_ptr<const Interest> interest_;
-	  Transport& transport_;
-	  MillisecondsSince1970 timeoutTimeMilliseconds_; /**< The time when the
+	  ndn::ptr_lib::shared_ptr<const ndn::Interest> interest_;
+	  ndn::Transport& transport_;
+	  ndn::MillisecondsSince1970 timeoutTimeMilliseconds_; /**< The time when the
 		* interest times out in milliseconds according to ndn_getNowMilliseconds,
 		* or -1 for no timeout. */
 	};
 	
   private:
-    Name broadcastPrefix_;
-    Name certificateName_;
+    ndn::Name broadcastPrefix_;
+    ndn::Name certificateName_;
     
     OnReceivedSyncData onReceivedSyncData_;
     
-    Face& face_;
-    MemoryContentCache contentCache_;
+    ndn::Face& face_;
+    ndn::MemoryContentCache contentCache_;
     
-    KeyChain& keyChain_;
+    ndn::KeyChain& keyChain_;
     
     // This serves as the rootDigest in ChronoSync.
     std::string currentDigest_;
@@ -311,7 +311,7 @@ namespace conference_discovery
     std::vector<std::string> objects_;
     
     // PendingInterestTable for holding outstanding interests.
-    std::vector<ptr_lib::shared_ptr<PendingInterest> > pendingInterestTable_;
+    std::vector<ndn::ptr_lib::shared_ptr<PendingInterest> > pendingInterestTable_;
   };
 }
 

--- a/src/chrono-chat.cpp
+++ b/src/chrono-chat.cpp
@@ -5,7 +5,8 @@
  */
 
 #include "chrono-chat.h"
-
+#include "chatbuf.pb.h"
+ 
 using namespace std;
 using namespace ndn;
 using namespace ndn::func_lib;

--- a/src/conference-discovery-sync.cpp
+++ b/src/conference-discovery-sync.cpp
@@ -1,4 +1,5 @@
 #include "conference-discovery-sync.h"
+#include "sync-based-discovery.h"
 #include <sys/time.h>
 #include <openssl/rand.h>
 #include <iostream>


### PR DESCRIPTION
- changed package name from URL to “ndn-conference-discovey” (this of
  course could be anything that identifies libraries, but URL)
- added public includes in Makefile.am
- removed “using namespace” in headers (commented out)
- modified serializeName and deserializeName of ConfierenceInfo
